### PR TITLE
Refactor how Extents works

### DIFF
--- a/src/silvimetric/commands/extract.py
+++ b/src/silvimetric/commands/extract.py
@@ -50,7 +50,7 @@ def extract(config: ExtractConfig):
     storage = Storage.from_db(config.tdb_dir)
     root_bounds=storage.config.bounds
 
-    e = Extents(config.bounds, config.resolution, root=root_bounds)
+    e = Extents(config.bounds, config.resolution, root_bounds)
     i = e.indices
     minx = i['x'].min()
     maxx = i['x'].max()

--- a/src/silvimetric/commands/shatter.py
+++ b/src/silvimetric/commands/shatter.py
@@ -90,7 +90,7 @@ def shatter(config: ShatterConfig):
     extents = Extents.from_sub(config.tdb_dir, config.bounds, config.tile_size)
 
     data = Data(config.filename, storage.config, extents.bounds)
-    leaves = extents.chunk(data, 1000)
+    leaves = extents.chunk(data, 100)
 
     # Begin main operations
     config.log.debug('Fetching and arranging data...')

--- a/src/silvimetric/resources/extents.py
+++ b/src/silvimetric/resources/extents.py
@@ -11,8 +11,9 @@ from .data import Data
 
 class Extents(object):
 
-    def __init__(self, bounds: Bounds, resolution: float, tile_size: int=16,
-                 root: Bounds=None):
+    def __init__(self, bounds: Bounds, resolution: float,
+                 root: Bounds,
+                 tile_size: int = 16):
 
         self.bounds = bounds
 
@@ -56,8 +57,7 @@ class Extents(object):
         miny = bmaxy - ((self.y2 + y_buf) * self.resolution)
         maxy = bmaxy - (self.y1 * self.resolution)
 
-        chunk = Extents(Bounds(minx, miny, maxx, maxy), self.resolution, self.tile_size,
-                       root=r)
+        chunk = Extents(Bounds(minx, miny, maxx, maxy), self.resolution, r, self.tile_size)
         self.root_chunk: Extents = chunk
 
         filtered = chunk.filter(data, threshold)
@@ -91,13 +91,13 @@ class Extents(object):
         midy = miny + ((maxy - miny)/ 2)
         yield from [
             Extents(Bounds(minx, miny, midx, midy), self.resolution,
-                    self.tile_size, self.root), #lower left
+                    self.root, self.tile_size), #lower left
             Extents(Bounds(midx, miny, maxx, midy), self.resolution,
-                   self.tile_size, self.root), #lower right
+                    self.root, self.tile_size), #lower right
             Extents(Bounds(minx, midy, midx, maxy), self.resolution,
-                   self.tile_size, self.root), #top left
+                    self.root, self.tile_size), #top left
             Extents(Bounds(midx, midy, maxx, maxy), self.resolution,
-                   self.tile_size, self.root)  #top right
+                    self.root, self.tile_size)  #top right
         ]
 
     # create quad tree of chunks for this bounds, run pdal quickinfo over this
@@ -152,7 +152,7 @@ class Extents(object):
         coords_list = np.array([[*x,*y] for x in dx for y in dy],dtype=np.float64)
         yield from [
             Extents(Bounds(minx, miny, maxx, maxy), self.resolution,
-                   self.tile_size, self.root)
+                   self.root, self.tile_size)
             for minx,maxx,miny,maxy in coords_list
         ]
 
@@ -160,7 +160,7 @@ class Extents(object):
     def from_storage(tdb_dir: str, tile_size: float=16):
         storage = Storage.from_db(tdb_dir)
         meta = storage.getConfig()
-        return Extents(meta.bounds, meta.resolution, tile_size)
+        return Extents(meta.bounds, meta.resolution, meta.bounds, tile_size)
 
     @staticmethod
     def from_sub(tdb_dir: str, sub: Bounds, tile_size: float=16):
@@ -169,7 +169,7 @@ class Extents(object):
 
         meta = storage.getConfig()
         res = meta.resolution
-        base_extents = Extents(meta.bounds, res, tile_size)
+        base_extents = Extents(meta.bounds, res, meta.bounds, tile_size)
         base = base_extents.bounds
 
 
@@ -191,7 +191,7 @@ class Extents(object):
             maxy = base.maxy - math.floor((base.maxy-sub.maxy)/res) * res
 
         new_b = Bounds(minx, miny, maxx, maxy)
-        return Extents(new_b, res, tile_size, base)
+        return Extents(new_b, res, base, tile_size)
 
 
     # @staticmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,9 +117,9 @@ def bounds(minx, maxx, miny, maxy) -> Bounds:
     b =  Bounds(minx, miny, maxx, maxy)
     yield b
 
-@pytest.fixture(scope='class')
-def extents(resolution, tile_size, bounds) -> Extents:
-    yield Extents(bounds,resolution,tile_size)
+@pytest.fixture(scope='function')
+def extents(resolution, tile_size, bounds, storage_config) -> Extents:
+    yield Extents(bounds,resolution, storage_config.bounds, tile_size)
 
 @pytest.fixture(scope="session")
 def attrs(dims) -> list[str]:


### PR DESCRIPTION
Extents is not ideal.

* Is not efficient if we are a small patch in a large area. In the scenario where we have a single TileDB for all of the Western US and we are inserting a small patch into it, Extents allocations its `self.indices` for every possible cell. This allocation fails on my mac.
* Confusing relationships of bounds/indices/root

Let's refactor this to be an instance of `Tile` with the following properties:

* Always take in a `root` *Bounds* instance and compute its relative position to that
* Do all of its math in indices instead of world coordinates. Only emit world coordinates when needed
* It should have a single `size` attribute and it is always square
* Overlaps with `root` happen to the top and to the right