### PR TITLE
Kmann/western

### DIFF
--- a/src/silvimetric/cli/cli.py
+++ b/src/silvimetric/cli/cli.py
@@ -117,7 +117,7 @@ def shatter_cmd(app, pointcloud, workers, bounds, threads, watch, report,
     """Insert data provided by POINTCLOUD into the silvimetric DATABASE"""
     dask_handle(dasktype, workers, threads, watch)
     config = ShatterConfig(tdb_dir = app.tdb_dir,
-                            date=dates if dates else tuple(date),
+                            date=dates if dates else tuple([date]),
                             log = app.log,
                             filename = pointcloud,
                             bounds = bounds,

--- a/src/silvimetric/cli/cli.py
+++ b/src/silvimetric/cli/cli.py
@@ -57,6 +57,7 @@ def info_cmd(app, bounds, date, dates, name):
 @click.argument("pointcloud", type=str)
 @click.option("--resolution", type=float, default=100)
 @click.option("--point_count", type=int, default=600000)
+@click.option("--depth", type=int, default=6)
 @click.option("--bounds", type=BoundsParamType(), default=None)
 @click.option("--workers", type=int, default=12)
 @click.option("--threads", type=int, default=4)
@@ -65,15 +66,15 @@ def info_cmd(app, bounds, date, dates, name):
               'threads', 'processes', 'single-threaded']))
 @click.pass_obj
 def scan_cmd(app, resolution, point_count, pointcloud, bounds, dasktype, workers,
-         threads, watch):
+             depth, threads, watch):
     """Scan point cloud and determine the optimal tile size."""
     dask_handle(dasktype, workers, threads, watch)
-    return scan.scan(app.tdb_dir, pointcloud, bounds, point_count, resolution)
+    return scan.scan(app.tdb_dir, pointcloud, bounds, point_count, resolution, depth)
 
 
 @cli.command('initialize')
-@click.argument("bounds", type=BoundsParamType())
-@click.argument("crs", type=CRSParamType())
+@click.option("--bounds", type=BoundsParamType(), required=True)
+@click.option("--crs", type=CRSParamType(), required=True)
 @click.option("--attributes", "-a", multiple=True, type=AttrParamType(),
               help="List of attributes to include in Database")
 @click.option("--metrics", "-m", multiple=True, type=MetricParamType(),

--- a/src/silvimetric/cli/common.py
+++ b/src/silvimetric/cli/common.py
@@ -43,7 +43,7 @@ class MetricParamType(click.ParamType):
     name="Metrics"
     def convert(self, value, param, ctx) -> list[Metric]:
         try:
-            return [Metrics[m] for m in value]
+            return Metrics[value]
         except Exception as e:
             self.fail(f"{value!r} is not available in Metrics, {e}", param, ctx)
 

--- a/src/silvimetric/cli/common.py
+++ b/src/silvimetric/cli/common.py
@@ -58,8 +58,8 @@ def dask_handle(dasktype: str, scheduler: str, workers: int, threads: int,
 
     if scheduler == 'local':
         if scheduler != 'distributed':
-            log.warning("""Selected scheduler type does not support continuously\
-                            updated config information.""")
+            log.warning("Selected scheduler type does not support continuously"
+                            "updated config information.")
         # fall back to dask type to determine the scheduler type
         dask_config['scheduler'] = dasktype
         if watch:
@@ -69,9 +69,9 @@ def dask_handle(dasktype: str, scheduler: str, workers: int, threads: int,
     elif scheduler == 'distributed':
         dask_config['scheduler'] = scheduler
         if dasktype == 'processes':
-            cluster = LocalCluster(processes=True)
+            cluster = LocalCluster(processes=True, n_workers=workers, threads_per_worker=threads)
         elif dasktype == 'threads':
-            cluster = LocalCluster(processes=False)
+            cluster = LocalCluster(processes=False, n_workers=workers, threads_per_worker=threads)
         else:
             raise ValueError(f"Invalid value for 'dasktype', {dasktype}")
 

--- a/src/silvimetric/commands/extract.py
+++ b/src/silvimetric/commands/extract.py
@@ -46,8 +46,9 @@ def create_metric_att_list(metrics: list[Metric], attrs: list[Attribute]):
 
 def extract(config: ExtractConfig):
 
-    ma_list = create_metric_att_list(config.metrics, config.attrs)
     storage = Storage.from_db(config.tdb_dir)
+    metadata = storage.getMetrics()
+    ma_list = create_metric_att_list(config.metrics, config.attrs)
     root_bounds=storage.config.root
 
     e = Extents(config.bounds, config.resolution, root=root_bounds)

--- a/src/silvimetric/commands/extract.py
+++ b/src/silvimetric/commands/extract.py
@@ -21,7 +21,7 @@ np_to_gdal_types = {
     np.dtype(np.float64).str: gdal.GDT_Float64
 }
 
-def write_tif(xsize: int, ysize: int, data:np.ndarray, name: str,
+def write_tif(xsize: int, ysize: int, data: np.ndarray, name: str,
               config: ExtractConfig):
     osr.UseExceptions()
     path = Path(config.out_dir) / f'{name}.tif'
@@ -44,14 +44,14 @@ def write_tif(xsize: int, ysize: int, data:np.ndarray, name: str,
     tif.FlushCache()
     tif = None
 
-def create_metric_att_list(metrics: list[Metric], attrs: list[Attribute]):
-    return [ m.entry_name(a.name) for m in metrics for a in attrs ]
-
 def extract(config: ExtractConfig):
 
     storage = Storage.from_db(config.tdb_dir)
-    ma_list = create_metric_att_list(config.metrics, config.attrs)
-    root_bounds=storage.config.root
+    ma_list = [ m.entry_name(a.name) for m in config.metrics for a in
+            config.attrs ]
+    att_list = [ a.name for a in config.attrs ] + [ 'count' ]
+    out_list = [ *ma_list, 'X', 'Y' ]
+    root_bounds = storage.config.root
 
     e = Extents(config.bounds, config.resolution, root=root_bounds)
     i = e.get_indices()
@@ -63,10 +63,8 @@ def extract(config: ExtractConfig):
     y1 = maxy - miny + 1
 
     with storage.open("r") as tdb:
-        att_list = [a.name for a in config.attrs] + ['count']
-        #TODO adjust the other data references to account for new query
-        data = tdb.query(attrs=[*ma_list, *att_list], use_arrow=False, order='F',
-                coords=True).df[minx:maxx, miny:maxy]
+        data = tdb.query(attrs=[*ma_list, *att_list], use_arrow=False,
+                order='F', coords=True).df[minx:maxx, miny:maxy]
         data['X'] = data['X'] - minx
         data['Y'] = data['Y'] - miny
 
@@ -79,28 +77,24 @@ def extract(config: ExtractConfig):
         leaves = data.loc[idx[np.where(counts == 1)]]
 
         # 2. then should combine the values of those attribute/cell combos
-        # ridx = np.unique(unq[redos])
-        # rxs = list(ridx['X'])
-        # rys = list(ridx['Y'])
-        # redo = pd.DataFrame(tdb.query(attrs=att_list).multi_index[[rxs], [rys]])
         recs = redos.groupby(['X','Y'], as_index=False).agg(
             lambda x: np.fromiter(itertools.chain(*x), x.dtype)
-            if x.dtype == object else sum(x))
+            if x.dtype == object else sum(x))[[*att_list, 'X', 'Y']]
         recs = recs.to_dict(orient='list')
 
-        # lidx = idx[leaves]
-        # lidx = np.unique(unq[leaves])
-        # lxs = list(lidx['X'])
-        # lys = list(lidx['Y'])
-
-        # leave = pd.DataFrame(tdb.query(attrs=ma_list).multi_index[[lxs], [lys]])
-        # leave = pd.DataFrame(tdb.query(attrs=ma_list).multi_index[[lxs], [lys]])
-
         # 3. Should rerun the metrics over them
-        dx, dy, metrics = get_metrics([[],[],recs[att_list]], att_list, storage)
-        ms = pd.DataFrame.from_dict(metrics)[[*ma_list, 'X', 'Y']]
-        final = pd.concat((ms, leaves))
+        dx, dy, metrics = get_metrics([[],[],recs], att_list, storage)
+        ms = pd.DataFrame.from_dict(metrics)[out_list]
+        final = pd.concat((ms, leaves[out_list]))
+
 
         # 4. output them to tifs
+        # TODO create empty df with nan values where there is no data
+        # TODO hook up dask into the cli so we can use it here
+        xs = final['X'].max() + 1
+        ys = final['Y'].max() + 1
         for ma in ma_list:
-            write_tif(x1, y1, final[ma].to_dict(orient='list'), ma, config)
+            raster_data = np.full((ys, xs), np.nan)
+            raster_idx = final['Y']*ys + final['X']
+            np.put(raster_data, raster_idx, final[ma])
+            write_tif(x1, y1, raster_data, ma, config)

--- a/src/silvimetric/commands/scan.py
+++ b/src/silvimetric/commands/scan.py
@@ -6,7 +6,7 @@ import math
 
 from ..resources import Storage, Data, Extents, Bounds
 
-def scan(tdb_dir, pointcloud, bounds, point_count, resolution, depth):
+def scan(tdb_dir, pointcloud, bounds, point_count=600000, resolution=100, depth=6):
     logger = logging.getLogger('silvimetric')
     with Storage.from_db(tdb_dir) as tdb:
         data = Data(pointcloud, tdb.config, bounds)

--- a/src/silvimetric/commands/scan.py
+++ b/src/silvimetric/commands/scan.py
@@ -6,12 +6,14 @@ import math
 
 from ..resources import Storage, Data, Extents, Bounds
 
-def scan(tdb_dir, pointcloud, bounds, point_count=600000, resolution=100, depth=6):
+def scan(tdb_dir, pointcloud, bounds, point_count=600000, resolution=100,
+        depth=6):
     logger = logging.getLogger('silvimetric')
     with Storage.from_db(tdb_dir) as tdb:
         data = Data(pointcloud, tdb.config, bounds)
         extents = Extents.from_sub(tdb_dir, data.bounds)
-        cell_counts = extent_handle(extents, data, resolution, point_count, depth)
+        cell_counts = extent_handle(extents, data, resolution, point_count,
+            depth)
 
         # total = np.array([l.cell_count for l in leaves])
         std = np.std(cell_counts)
@@ -26,8 +28,8 @@ def scan(tdb_dir, pointcloud, bounds, point_count=600000, resolution=100, depth=
         return rec
 
 
-def extent_handle(extent: Extents, data: Data, res_threshold=100, pc_threshold=600000,
-        depth_threshold=6):
+def extent_handle(extent: Extents, data: Data, res_threshold=100,
+        pc_threshold=600000, depth_threshold=6):
 
     if extent.root is not None:
         bminx, bminy, bmaxx, bmaxy = extent.root.get()
@@ -47,7 +49,8 @@ def extent_handle(extent: Extents, data: Data, res_threshold=100, pc_threshold=6
     if extent.bounds == extent.root:
         extent.root = chunk.bounds
 
-    curr = db.from_delayed(tile_info(chunk, data, res_threshold, pc_threshold, depth_threshold))
+    curr = db.from_delayed(tile_info(chunk, data, res_threshold, pc_threshold,
+            depth_threshold))
     logger = logging.getLogger('silvimetric')
     a = [ ]
 
@@ -100,4 +103,5 @@ def tile_info(extent: Extents, data: Data, res_threshold=100,
             return [ cell_estimate for x in range(tile_count) ] + [ remainder ]
 
         else:
-            return [ tile_info(ch, data, res_threshold, pc_threshold, depth_threshold, depth+1) for ch in extent.split() ]
+            return [ tile_info(ch, data, res_threshold, pc_threshold,
+                    depth_threshold, depth+1) for ch in extent.split() ]

--- a/src/silvimetric/commands/scan.py
+++ b/src/silvimetric/commands/scan.py
@@ -1,18 +1,21 @@
 import numpy as np
 import logging
+import dask.bag as db
+import dask
+import math
 
-from ..resources import Storage, Data, Extents, Log
+from ..resources import Storage, Data, Extents, Bounds
 
-def scan(tdb_dir, pointcloud, bounds, point_count, resolution):
+def scan(tdb_dir, pointcloud, bounds, point_count, resolution, depth):
     logger = logging.getLogger('silvimetric')
     with Storage.from_db(tdb_dir) as tdb:
         data = Data(pointcloud, tdb.config, bounds)
         extents = Extents.from_sub(tdb_dir, data.bounds)
-        leaves = extents.chunk(data, resolution, point_count)
+        cell_counts = extent_handle(extents, data, resolution, point_count, depth)
 
-        total = np.array([l.cell_count for l in leaves])
-        std = np.std(total)
-        mean = np.mean(total)
+        # total = np.array([l.cell_count for l in leaves])
+        std = np.std(cell_counts)
+        mean = np.mean(cell_counts)
         rec = int(mean + std)
 
         logger.info(f'Tiling information:')
@@ -21,3 +24,80 @@ def scan(tdb_dir, pointcloud, bounds, point_count, resolution):
         logger.info(f'  Recommended split size: {rec}')
 
         return rec
+
+
+def extent_handle(extent: Extents, data: Data, res_threshold=100, pc_threshold=600000,
+        depth_threshold=6):
+
+    if extent.root is not None:
+        bminx, bminy, bmaxx, bmaxy = extent.root.get()
+        r = extent.root
+    else:
+        bminx, bminy, bmaxx, bmaxy = extent.bounds.get()
+        r = extent.bounds
+
+    # make bounds in scale with the desired resolution
+    minx = bminx + (extent.x1 * extent.resolution)
+    maxx = bminx + (extent.x2 * extent.resolution)
+    miny = bmaxy - (extent.y2 * extent.resolution)
+    maxy = bmaxy - (extent.y1 * extent.resolution)
+
+    chunk = Extents(Bounds(minx, miny, maxx, maxy), extent.resolution, r)
+
+    if extent.bounds == extent.root:
+        extent.root = chunk.bounds
+
+    curr = db.from_delayed(tile_info(chunk, data, res_threshold, pc_threshold, depth_threshold))
+    logger = logging.getLogger('silvimetric')
+    a = [ ]
+
+    curr_depth = 0
+    while curr.npartitions > 0:
+        logger.info(f'Chunking {curr.npartitions} tiles at depth {curr_depth}')
+        n = curr.compute()
+        to_add = [ x for x in n if isinstance(x, int) ]
+        a = a + to_add
+
+        to_next = [ x for x in n if not isinstance(x, int) ]
+
+        curr = db.from_delayed(to_next)
+        curr_depth += 1
+
+    return list(a)
+
+
+@dask.delayed
+def tile_info(extent: Extents, data: Data, res_threshold=100,
+        pc_threshold=600000, depth_threshold=6, depth=0):
+
+
+    pc = data.estimate_count(extent.bounds)
+    target_pc = pc_threshold
+    minx, miny, maxx, maxy = extent.bounds.get()
+
+    # is it empty?
+    if not pc:
+        return [ ]
+    else:
+        # has it hit the threshold yet?
+        area = (maxx - minx) * (maxy - miny)
+        next_split_x = (maxx-minx) / 2
+        next_split_y = (maxy-miny) / 2
+
+        # if the next split would put our area below the resolution, or if
+        # the point count is less than the threshold (600k) then use this
+        # tile as the work unit.
+        if next_split_x < extent.resolution or next_split_y < extent.resolution:
+            return [ extent.cell_count ]
+        elif pc < target_pc:
+            return [ extent.cell_count ]
+        elif area < res_threshold**2 or depth >= depth_threshold:
+            pc_per_cell = pc / (area / extent.resolution**2)
+            cell_estimate = math.ceil(target_pc / pc_per_cell)
+            tile_count = math.floor(extent.cell_count / cell_estimate)
+            remainder = extent.cell_count % cell_estimate
+
+            return [ cell_estimate for x in range(tile_count) ] + [ remainder ]
+
+        else:
+            return [ tile_info(ch, data, res_threshold, pc_threshold, depth_threshold, depth+1) for ch in extent.split() ]

--- a/src/silvimetric/commands/shatter.py
+++ b/src/silvimetric/commands/shatter.py
@@ -81,9 +81,17 @@ def write(data_in, tdb):
     dx, dy, dd = data_in
     tdb[dx,dy] = dd
     pc = int(dd['count'].sum())
-    del data_in
 
     return pc
+
+def garbage(pc, points, leaf, att_data, arranged, metrics):
+    import gc
+    import copy
+
+    p = copy.copy(pc)
+    del pc, points, leaf, att_data, arranged, metrics
+    am = gc.collect()
+    return p
 
 def run(leaves: db.Bag, config: ShatterConfig, storage: Storage, tdb: SparseArray):
     attrs = [a.name for a in config.attrs]
@@ -95,7 +103,9 @@ def run(leaves: db.Bag, config: ShatterConfig, storage: Storage, tdb: SparseArra
     arranged: db.Bag = att_data.map(arrange, leaf_bag, attrs)
     metrics: db.Bag = arranged.map(get_metrics, attrs, storage)
     writes: db.Bag = metrics.map(write, tdb)
-    return sum(writes)
+    pc: db.Bag = writes.map(garbage, points, leaves, att_data, arranged, metrics)
+
+    return sum(pc)
 
 
 

--- a/src/silvimetric/commands/shatter.py
+++ b/src/silvimetric/commands/shatter.py
@@ -14,6 +14,7 @@ from tiledb import SparseArray
 from ..resources import Extents, Storage, ShatterConfig, Data
 
 def get_data(extents: Extents, filename: str, storage: Storage):
+    #TODO look at making a record array here
     data = Data(filename, storage.config, bounds = extents.bounds)
     data.execute()
     return data.array

--- a/src/silvimetric/resources/config.py
+++ b/src/silvimetric/resources/config.py
@@ -162,6 +162,8 @@ class ShatterConfig(Config):
     bounds: Union[Bounds, None] = field(default=None)
     name: uuid.UUID = field(default=uuid.uuid4())
     tile_size: Union[int, None] = field(default=None)
+    start_time:float = 0
+    end_time:float = 0
     point_count: int = 0
     nonempty_domain: tuple[tuple[int, int], ...] = ()
     finished: bool = False

--- a/src/silvimetric/resources/config.py
+++ b/src/silvimetric/resources/config.py
@@ -161,9 +161,9 @@ class ShatterConfig(Config):
     bounds: Union[Bounds, None] = field(default=None)
     name: uuid.UUID = field(default=uuid.uuid4())
     tile_size: Union[int, None] = field(default=None)
-    point_count: int = field(default=0)
-    nonempty_domain: tuple[tuple[int, int], ...] = field(default=())
-    finished: bool = field(default=False)
+    point_count: int = 0
+    nonempty_domain: tuple[tuple[int, int], ...] = ()
+    finished: bool = False
 
     def __post_init__(self) -> None:
         from .storage import Storage
@@ -183,6 +183,8 @@ class ShatterConfig(Config):
         d['bounds'] = json.loads(self.bounds.to_json()) if self.bounds is not None else None
         d['attrs'] = [a.to_json() for a in self.attrs]
         d['metrics'] = [m.to_json() for m in self.metrics]
+        d['nonempty_domain'] = [ list(a) for a in self.nonempty_domain]
+
         if isinstance(self.date, tuple):
             d['date'] = [ dt.strftime('%Y-%m-%dT%H:%M:%SZ') for dt in self.date]
         else:
@@ -199,6 +201,7 @@ class ShatterConfig(Config):
             date = tuple(( datetime.strptime(d, '%Y-%m-%dT%H:%M:%SZ') for d in x['date']))
         else:
             date = datetime.strptime(x['date'], '%Y-%m-%dT%H:%M:%SZ')
+        nonempty_domains = tuple(tuple(ned) for ned in x['nonempty_domain'])
         # TODO key error if these aren't there. If we're calling from_string
         # then these keys need to exist.
 
@@ -209,6 +212,7 @@ class ShatterConfig(Config):
                 debug = x['debug'],
                 name = uuid.UUID(x['name']),
                 bounds=Bounds(*x['bounds']),
+                nonempty_domain=nonempty_domains,
                 date= date)
 
         return n

--- a/src/silvimetric/resources/config.py
+++ b/src/silvimetric/resources/config.py
@@ -161,7 +161,9 @@ class ShatterConfig(Config):
     bounds: Union[Bounds, None] = field(default=None)
     name: uuid.UUID = field(default=uuid.uuid4())
     tile_size: Union[int, None] = field(default=None)
-    point_count: int = 0
+    point_count: int = field(default=0)
+    nonempty_domain: tuple[tuple[int, int], ...] = field(default=())
+    finished: bool = field(default=False)
 
     def __post_init__(self) -> None:
         from .storage import Storage
@@ -171,7 +173,6 @@ class ShatterConfig(Config):
             self.attrs = s.getAttributes()
         if not self.metrics:
             self.metrics = s.getMetrics()
-        self.point_count: int = 0
 
         del s
 

--- a/src/silvimetric/resources/config.py
+++ b/src/silvimetric/resources/config.py
@@ -136,6 +136,7 @@ class StorageConfig(Config):
 class ApplicationConfig(Config):
     debug: bool = False,
     progress: bool = False,
+    scheduler: str = 'distributed'
 
     def to_json(self):
         d = super().to_json()
@@ -224,8 +225,8 @@ class ShatterConfig(Config):
 @dataclass
 class ExtractConfig(Config):
     out_dir: str
-    attrs: list[str] = field(default_factory=list)
-    metrics: list[str] = field(default_factory=list)
+    attrs: list[Attribute] = field(default_factory=list)
+    metrics: list[Metric] = field(default_factory=list)
     bounds: Bounds = field(default=None)
 
     def __post_init__(self) -> None:

--- a/src/silvimetric/resources/data.py
+++ b/src/silvimetric/resources/data.py
@@ -1,4 +1,3 @@
-
 from . import Bounds
 from .config import StorageConfig
 import numpy as np
@@ -6,7 +5,6 @@ import numpy as np
 import pdal
 
 import pathlib
-from urllib.parse import urlparse
 import json
 
 class Data:

--- a/src/silvimetric/resources/data.py
+++ b/src/silvimetric/resources/data.py
@@ -6,6 +6,7 @@ import numpy as np
 import pdal
 
 import pathlib
+from urllib.parse import urlparse
 import json
 
 class Data:
@@ -30,7 +31,7 @@ class Data:
         """Does this instance represent a pdal.Pipeline or a simple filename"""
 
         p = pathlib.Path(self.filename)
-        if p.suffix == '.json':
+        if p.suffix == '.json' and p.name != 'ept.json':
             return True
         return False
 

--- a/src/silvimetric/resources/extents.py
+++ b/src/silvimetric/resources/extents.py
@@ -160,7 +160,7 @@ class Extents(object):
         dy = self.root.maxy - (res * local_ys)
 
         coords_list = np.array([[*x,*y] for x in dx for y in dy],dtype=np.float64)
-        return [
+        yield from [
             Extents(Bounds(minx, miny, maxx, maxy), self.resolution, self.root)
             for minx,maxx,miny,maxy in coords_list
         ]

--- a/src/silvimetric/resources/metric.py
+++ b/src/silvimetric/resources/metric.py
@@ -23,8 +23,8 @@ class Metric(Entry):
         self.dependencies = deps
         self._method = method
 
-    def schema(self, attr: str):
-        entry_name = self.entry_name(attr)
+    def schema(self, attr: Attribute):
+        entry_name = self.entry_name(attr.name)
         return Attr(name=entry_name, dtype=self.dtype)
 
     # common name, storage name
@@ -88,11 +88,12 @@ def m_max(data):
 def m_stddev(data):
     return np.std(data)
 
+#TODO change to correct dtype
 Metrics = {
-    'mean' : Metric('mean', np.float64, m_mean),
-    'mode' : Metric('mode', np.float64, m_mode),
-    'median' : Metric('median', np.float64, m_median),
-    'min' : Metric('min', np.float64, m_min),
-    'max' : Metric('max', np.float64, m_max),
-    'stddev' : Metric('stddev', np.float64, m_stddev),
+    'mean' : Metric('mean', np.float32, m_mean),
+    'mode' : Metric('mode', np.float32, m_mode),
+    'median' : Metric('median', np.float32, m_median),
+    'min' : Metric('min', np.float32, m_min),
+    'max' : Metric('max', np.float32, m_max),
+    'stddev' : Metric('stddev', np.float32, m_stddev),
 }

--- a/src/silvimetric/resources/storage.py
+++ b/src/silvimetric/resources/storage.py
@@ -56,6 +56,8 @@ class Storage:
             Raises bounding box errors if not of lengths 4 or 6
         """
 
+        # TODO make any changes to tiledb setup here.
+
         if not ctx:
             ctx = tiledb.default_ctx()
 
@@ -70,7 +72,7 @@ class Storage:
         count_att = tiledb.Attr(name="count", dtype=np.int32)
         dim_atts = [attr.schema() for attr in config.attrs]
 
-        metric_atts = [m.schema(a.name) for m in config.metrics for a in config.attrs]
+        metric_atts = [m.schema(a) for m in config.metrics for a in config.attrs]
 
         # allows_duplicates lets us insert multiple values into each cell,
         # with each value representing a set of values from a shatter process

--- a/tests/test_chunk.py
+++ b/tests/test_chunk.py
@@ -2,6 +2,7 @@ import numpy as np
 import dask
 import pdal
 import pytest
+import datetime
 
 from silvimetric.resources import Extents
 from silvimetric.commands.shatter import run
@@ -120,8 +121,9 @@ class TestExtents(object):
     def test_pointcount(self, filtered, unfiltered, test_point_count, shatter_config, storage):
 
         with storage.open('w') as tdb:
-            fc = run(filtered, shatter_config, storage, tdb)
-            ufc = run(unfiltered, shatter_config, storage, tdb)
+            start_time = datetime.datetime.now().timestamp() * 1000
+            fc = run(filtered, shatter_config, storage, tdb, start_time)
+            ufc = run(unfiltered, shatter_config, storage, tdb, start_time)
 
             assert fc == ufc, f"""
                 Filtered and unfiltered point counts don't match.

--- a/tests/test_chunk.py
+++ b/tests/test_chunk.py
@@ -121,9 +121,9 @@ class TestExtents(object):
     def test_pointcount(self, filtered, unfiltered, test_point_count, shatter_config, storage):
 
         with storage.open('w') as tdb:
-            start_time = datetime.datetime.now().timestamp() * 1000
-            fc = run(filtered, shatter_config, storage, tdb, start_time)
-            ufc = run(unfiltered, shatter_config, storage, tdb, start_time)
+            shatter_config.start_time = datetime.datetime.now().timestamp() * 1000
+            fc = run(filtered, shatter_config, storage, tdb)
+            ufc = run(unfiltered, shatter_config, storage, tdb)
 
             assert fc == ufc, f"""
                 Filtered and unfiltered point counts don't match.

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -41,8 +41,10 @@ class TestCommands(object):
 
     def test_scan(self, shatter_config):
         s = shatter_config
-        res = scan.scan(s.tdb_dir, s.filename, s.bounds, 10, 10)
-        assert res == 25
+        res = scan.scan(s.tdb_dir, s.filename, s.bounds, 10, 10, 5)
+        assert res == 1
+        res = scan.scan(s.tdb_dir, s.filename, s.bounds, depth=5)
+        assert res == 100
 
     def test_info(self, tdb_filepath, config_split):
         i = info.info(tdb_filepath)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -4,7 +4,7 @@ import os
 import dataclasses
 
 
-from silvimetric.resources import StorageConfig, Bounds, Log
+from silvimetric.resources import StorageConfig, Bounds, Log, Metric
 
 @pytest.fixture(scope='function')
 def tdb_filepath(tmp_path_factory) -> str:
@@ -32,5 +32,9 @@ class Test_Configuration(object):
 
         j = str(config)
         c = StorageConfig.from_string(j)
+        mean = [ m for m in c.metrics if m.name == 'mean']
+        assert len(mean) == 1
+
+        assert int(mean[0]([2,2,2,2])) == 2
         assert config == c
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -28,6 +28,18 @@ def extract_config(tdb_filepath, tif_filepath, metrics, shatter_config, extract_
                        metrics = metrics)
     yield c
 
+@pytest.fixture(scope='function')
+def multivalue_config(tdb_filepath, tif_filepath, metrics, shatter_config, extract_attrs):
+    shatter(shatter_config)
+    shatter(shatter_config)
+    log = Log(20)
+    c =  ExtractConfig(tdb_dir = tdb_filepath,
+                       log = log,
+                       out_dir = tif_filepath,
+                       attrs = extract_attrs,
+                       metrics = metrics)
+    yield c
+
 
 
 def tif_test(extract_config):
@@ -81,3 +93,5 @@ class Test_Extract(object):
                                bounds = b.bounds)
             extract(ec)
             tif_test(ec)
+
+    def test_multi_value(self, shatter_config, tdb_filepath)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -47,7 +47,5 @@ class Test_Storage(object):
                 def e_name(att):
                     return s.attr(m.entry_name(att.name))
                 def schema(att):
-                    return Metrics[m.name].schema(att.name)
+                    return Metrics[m.name].schema(att)
                 assert all([e_name(a) == schema(a) for a in a_list])
-
-

--- a/tests/test_western.py
+++ b/tests/test_western.py
@@ -1,0 +1,53 @@
+import tiledb
+import tempfile
+import numpy as np
+from silvimetric.resources import Storage, StorageConfig, Metrics, Attribute, Bounds
+
+from silvimetric.commands.shatter import shatter
+from silvimetric.resources import Storage, Extents, ShatterConfig, Log
+from silvimetric import __version__ as svversion
+import os, shutil
+import pytest
+
+@pytest.fixture(scope="class")
+def WebMercator():
+    yield "EPSG:3857"
+
+@pytest.fixture(scope='class')
+def WesternBounds() -> Bounds:
+    b = Bounds(-14100053.268191, 3058230.975702, -11138180.816218, 6368599.176434)
+    yield b
+
+@pytest.fixture(scope='function')
+def western_filepath(tmp_path_factory):
+
+    temp_name = next(tempfile._get_candidate_names())
+    path = tmp_path_factory.mktemp(temp_name)
+    yield os.path.abspath(path)
+    shutil.rmtree(path)
+
+
+@pytest.fixture(scope='function')
+def western_config(western_filepath, WesternBounds, resolution, WebMercator, attrs, metrics):
+    log = Log(20)
+    yield StorageConfig(tdb_dir = western_filepath,
+                        log = log,
+                        crs = WebMercator,
+                        root = WesternBounds,
+                        resolution = resolution,
+                        attrs = attrs,
+                        metrics = metrics,
+                        version = svversion)
+
+@pytest.fixture(scope='function')
+def western_storage(western_config) -> Storage:
+    yield Storage.create(western_config)
+
+class Test_Western(object):
+
+    def test_schema(self, western_storage: Storage):
+        with western_storage.open('r') as st:
+            s:tiledb.ArraySchema = st.schema
+            assert s.has_attr('count')
+            assert s.attr('count').dtype == np.int32
+

--- a/tests/test_western.py
+++ b/tests/test_western.py
@@ -43,6 +43,28 @@ def western_config(western_filepath, WesternBounds, resolution, WebMercator, att
 def western_storage(western_config) -> Storage:
     yield Storage.create(western_config)
 
+@pytest.fixture(scope='function')
+def western_pipeline():
+    path = os.path.join(os.path.dirname(__file__), "data",
+            "western_us.json")
+    assert os.path.exists(path)
+    yield os.path.abspath(path)
+
+@pytest.fixture(scope='function')
+def western_shatter_config(western_pipeline, western_storage):
+    log = Log(20) # INFO
+    st = western_storage.config
+
+    s = ShatterConfig(tdb_dir = st.tdb_dir,
+        log = log,
+        filename = western_pipeline,
+        attrs = st.attrs,
+        metrics = st.metrics,
+        bounds=bounds,
+        debug = True,
+        date=date)
+    yield s
+
 class Test_Western(object):
 
     def test_schema(self, western_storage: Storage):


### PR DESCRIPTION
 - QoL changes
 - Clarity changes
 - Extract now creates output even if there overlapping data in tile. Data doesn't need to be consolidated before extracting.
 - Added modified filter method as new scan method 
 - Added ability to kill a task mid process, should now fail "gracefully", outputting the config to tiledb indicating that it wasn't finished, and noting which cells it touched and how many points it processed before dying. Failing gracefully works for all dask schedulers, but point updates can only be supported with a `distributed` set.