### PR TITLE
Stability update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,17 @@ __pycache__/
 build/
 dist/
 stats/
-.env
 
 *.html
 **/html/**
 **/_build/**
+
+# local conda environment
+# conda env create --prefix .conda/ -f environment.yml
+.conda/**
+
+# environment variables for pytest
+.env
 
 #tiledb
 **/__fragments/**

--- a/environment.yml
+++ b/environment.yml
@@ -2,9 +2,9 @@ name: silvimetric
 channels:
   - conda-forge
 dependencies:
-  - python
+  - python>=3.10
   - pip
-  - tiledb-py
+  - tiledb-py>=0.32.5
   - pdal
   - python-pdal
   - numpy
@@ -19,3 +19,4 @@ dependencies:
   - dill
   - pandas
   - lmoments3
+  - typing_extensions

--- a/src/silvimetric/__init__.py
+++ b/src/silvimetric/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.2.3'
+__version__ = '1.3.0'
 
 from .resources.bounds import Bounds
 from .resources.extents import Extents

--- a/src/silvimetric/commands/extract.py
+++ b/src/silvimetric/commands/extract.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from itertools import chain
 
 
-from typing import Union
+from typing_extensions import Union
 from osgeo import gdal, osr
 import dask
 import numpy as np

--- a/src/silvimetric/commands/info.py
+++ b/src/silvimetric/commands/info.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from uuid import UUID
-from typing import Union
+from typing_extensions import Union
 
 from .. import Storage, Bounds
 

--- a/src/silvimetric/commands/shatter.py
+++ b/src/silvimetric/commands/shatter.py
@@ -2,7 +2,7 @@ import numpy as np
 import signal
 import datetime
 import copy
-from typing import Generator
+from typing_extensions import Generator
 import pandas as pd
 import tiledb
 

--- a/src/silvimetric/resources/array_extensions.py
+++ b/src/silvimetric/resources/array_extensions.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Sequence
+from typing_extensions import Sequence
 
 import re
 

--- a/src/silvimetric/resources/config.py
+++ b/src/silvimetric/resources/config.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from pathlib import Path
 from abc import ABC, abstractmethod
-from typing import Union, Tuple
+from typing_extensions import Union, Tuple
 from datetime import datetime
 
 from dataclasses import dataclass, field

--- a/src/silvimetric/resources/log.py
+++ b/src/silvimetric/resources/log.py
@@ -9,8 +9,7 @@ import logging
 import pathlib
 import sys
 
-from typing import Any
-from typing import Dict
+from typing_extensions import Any, Dict
 
 try:
     import websocket

--- a/src/silvimetric/resources/metric.py
+++ b/src/silvimetric/resources/metric.py
@@ -1,7 +1,8 @@
 import json
 import base64
 
-from typing import Callable, Optional, Any, Union, List, Self
+from typing_extensions import Self, Callable, Optional, Any, Union, List
+
 from uuid import uuid4
 from functools import reduce
 

--- a/src/silvimetric/resources/storage.py
+++ b/src/silvimetric/resources/storage.py
@@ -6,7 +6,7 @@ import pathlib
 import contextlib
 import json
 import urllib
-from typing import Generator
+from typing_extensions import Generator
 
 from math import floor
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import pdal
 import copy
 
 from datetime import datetime
-from typing import Generator
+from typing_extensions import Generator
 
 from silvimetric import Extents, Bounds, Attribute, Storage
 from silvimetric import grid_metrics

--- a/tests/fixtures/chunk_fixtures.py
+++ b/tests/fixtures/chunk_fixtures.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 
-from typing import Generator, List
+from typing_extensions import Generator, List
 
 from silvimetric import Extents, Data
 

--- a/tests/fixtures/cli_fixtures.py
+++ b/tests/fixtures/cli_fixtures.py
@@ -1,5 +1,5 @@
 import pytest
-from typing import Generator
+from typing_extensions import Generator
 from click.testing import CliRunner
 
 from silvimetric.commands import shatter

--- a/tests/fixtures/command_fixtures.py
+++ b/tests/fixtures/command_fixtures.py
@@ -2,7 +2,7 @@ import uuid
 import pytest
 
 from time import sleep
-from typing import List, Generator
+from typing_extensions import List, Generator
 from datetime import datetime
 
 from silvimetric.commands import shatter

--- a/tests/fixtures/dask_fixtures.py
+++ b/tests/fixtures/dask_fixtures.py
@@ -1,6 +1,6 @@
 import pytest
 import os
-from typing import Generator
+from typing_extensions import Generator
 import dask
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/fixtures/data_fixtures.py
+++ b/tests/fixtures/data_fixtures.py
@@ -1,6 +1,6 @@
 import pytest
 import os
-from typing import Generator
+from typing_extensions import Generator
 
 @pytest.fixture(scope='session')
 def no_cell_line_pc() -> Generator[int, None, None]:

--- a/tests/fixtures/extract_fixtures.py
+++ b/tests/fixtures/extract_fixtures.py
@@ -2,7 +2,7 @@ import pytest
 import os
 import copy
 import uuid
-from typing import Generator
+from typing_extensions import Generator
 
 from silvimetric.commands.shatter import shatter
 from silvimetric import Attribute, ExtractConfig, Log, Bounds

--- a/tests/fixtures/metric_fixtures.py
+++ b/tests/fixtures/metric_fixtures.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from typing import Generator
+from typing_extensions import Generator
 import pandas as pd
 import numpy as np
 

--- a/tests/fixtures/shatter_fixtures.py
+++ b/tests/fixtures/shatter_fixtures.py
@@ -1,5 +1,5 @@
 import pytest
-from typing import Generator
+from typing_extensions import Generator
 from uuid import uuid4
 import os
 

--- a/tests/fixtures/western_fixtures.py
+++ b/tests/fixtures/western_fixtures.py
@@ -1,5 +1,5 @@
 import tempfile
-from typing import Generator
+from typing_extensions import Generator
 
 from silvimetric import Storage, ShatterConfig, Log, Bounds, StorageConfig
 from silvimetric import __version__ as svversion


### PR DESCRIPTION
Pinning versions of python and tiledb-py for stability purposes. 

Tiledb-py: Silvimetric works with the current version of tiledb, because of a change to how array fragments are collected from a database. 

Python 3.10: Google colab requires python 3.10, and some `typing` functionality was introduced in 3.11 that we needed to revert because of this pin, which is also included here.