### PR TITLE
Kmann/dep fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   test:
+    name: ${{ matrix.os }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     environment: testing
     timeout-minutes: 30
@@ -26,20 +27,23 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.10', '3.11', '3.12']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: mamba-org/setup-micromamba@v2
         with:
+          init-shell: bash
           miniforge-version: latest
           miniforge-variant: Mambaforge
           environment-file: environment.yml
           auto-update-conda: false
-          python-version: "3.11"
           use-mamba: true
           activate-environment: silvimetric
+          create-args: >-
+            python=${{ matrix.python-version }}
       - name: "Install Test Framework"
-        run: pip install pytest pytest-click
+        run: pip install pytest pytest-click awscli
       - name: "Install Package"
         run: pip install .
       - name: "Debug Info"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,12 +34,8 @@ jobs:
       - uses: mamba-org/setup-micromamba@v2
         with:
           init-shell: bash
-          miniforge-version: latest
-          miniforge-variant: Mambaforge
-          environment-file: environment.yml
-          auto-update-conda: false
-          use-mamba: true
-          activate-environment: silvimetric
+          environment-file: "environment.yml"
+          environment-name: "silvimetric"
           create-args: >-
             python=${{ matrix.python-version }}
       - name: "Install Test Framework"
@@ -52,7 +48,7 @@ jobs:
           echo python version: `python --version`
           echo pytest location: `which pytest`
           echo installed packages
-          conda list
+          micromamba list
           pip list
       - name: Run Tests
         env:
@@ -72,15 +68,11 @@ jobs:
           uses: actions/checkout@v4
           with:
             fetch-depth: 2
-        - uses: conda-incubator/setup-miniconda@v2
+        - uses: mamba-org/setup-micromamba@v2
           with:
-            miniforge-version: latest
-            miniforge-variant: Mambaforge
-            environment-file: environment.yml
-            auto-update-conda: false
-            python-version: "3.11"
-            use-mamba: true
-            activate-environment: silvimetric
+            init-shell: bash
+            environment-file: "environment.yml"
+            environment-name: "silvimetric"
         - name: Config CodeQL
           run: |
             echo "CODEQL_PYTHON=$(which python)" >> $GITHUB_ENV

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ stats/
 autzen-classified.copc.laz
 
 #sample metrics
-metrics/
 metrics_aligned/
 autzen-aligned.tdb/
 

--- a/environment.yml
+++ b/environment.yml
@@ -2,18 +2,17 @@ name: silvimetric
 channels:
   - conda-forge
 dependencies:
-  - python>=3.10
+  - python>=3.10, <3.13
   - pip
   - tiledb-py>=0.32.5
   - pdal
   - python-pdal
   - numpy
   - shapely
-  - dask
+  - dask>=2024.11.2
   - pyproj
   - gdal
   - scipy
-  - awscli
   - websocket-client
   - python-json-logger
   - dill

--- a/src/silvimetric/cli/cli.py
+++ b/src/silvimetric/cli/cli.py
@@ -102,8 +102,6 @@ def info_cmd(app, bounds, date, dates, name, history, metadata, attributes):
         return
 
 
-
-
 @cli.command("scan")
 @click.argument("pointcloud", type=str)
 @click.option("--resolution", type=float, default=100,
@@ -228,25 +226,22 @@ def extract_cmd(app, attributes, metrics, outdir, bounds):
     extract.extract(config)
 
 @cli.command('delete')
-@click.option('--id', type=click.UUID, required=True,
-    help="Shatter Task UUID.")
+@click.option('--id', type=click.UUID, required=True, help="Shatter Task UUID.")
 @click.pass_obj
 def delete_cmd(app, id):
-    manage.delete(app.tdb_dir, id)
+    manage.delete(tdb_dir=app.tdb_dir, name=id, log=app.log)
 
 @cli.command('restart')
-@click.option('--id', type=click.UUID, required=True,
-    help="Shatter Task UUID.")
+@click.option('--id', type=click.UUID, required=True, help="Shatter Task UUID.")
 @click.pass_obj
 def restart_cmd(app, id):
-    manage.restart(tdb_dir=app.tdb_dir, name=id)
+    manage.restart(tdb_dir=app.tdb_dir, name=id, log=app.log)
 
 @cli.command('resume')
-@click.option('--id', type=click.UUID, required=True,
-    help="Shatter Task UUID.")
+@click.option('--id', type=click.UUID, required=True, help="Shatter Task UUID.")
 @click.pass_obj
 def resume_cmd(app, id):
-    manage.resume(tdb_dir=app.tdb_dir, name=id)
+    manage.resume(tdb_dir=app.tdb_dir, name=id, log=app.log)
 
 if __name__ == "__main__":
     cli()

--- a/src/silvimetric/cli/common.py
+++ b/src/silvimetric/cli/common.py
@@ -128,19 +128,25 @@ def dask_handle(dasktype: str, scheduler: str, workers: int, threads: int,
             p.register()
 
     elif scheduler == 'distributed':
-        dask_config['scheduler'] = scheduler
-        if dasktype == 'processes':
-            cluster = LocalCluster(processes=True, n_workers=workers, threads_per_worker=threads)
-        elif dasktype == 'threads':
-            cluster = LocalCluster(processes=False, n_workers=workers, threads_per_worker=threads)
-        else:
-            raise ValueError(f"Invalid value for 'dasktype', {dasktype}")
+        raise Exception("Dask distributed scheduler is currently disabled. "
+            "Please select another scheduler ('single-threaded' or 'local')")
 
-        client = Client(cluster)
-        client.get_versions(check=True)
-        dask_config['distributed.client'] = client
-        if watch:
-            webbrowser.open(client.cluster.dashboard_link)
+        # TODO: this is disabled for now. Distributed dask keeps crashing when
+        # used for shatter.
+
+        # dask_config['scheduler'] = scheduler
+        # if dasktype == 'processes':
+        #     cluster = LocalCluster(processes=True, n_workers=workers, threads_per_worker=threads)
+        # elif dasktype == 'threads':
+        #     cluster = LocalCluster(processes=False, n_workers=workers, threads_per_worker=threads)
+        # else:
+        #     raise ValueError(f"Invalid value for 'dasktype', {dasktype}")
+
+        # client = Client(cluster)
+        # client.get_versions(check=True)
+        # dask_config['distributed.client'] = client
+        # if watch:
+        #     webbrowser.open(client.cluster.dashboard_link)
 
     elif scheduler == 'single-threaded':
         dask_config['scheduler'] = scheduler

--- a/src/silvimetric/cli/common.py
+++ b/src/silvimetric/cli/common.py
@@ -1,10 +1,13 @@
 import click
 import pyproj
 import webbrowser
+from contextlib import nullcontext
 
 import dask
 from dask.diagnostics import ProgressBar
 from dask.distributed import Client, LocalCluster
+from distributed.client import _get_global_client as get_client
+
 from ..resources.metrics import l_moments, percentiles, statistics, product_moments
 from ..resources.metrics import aad, grid_metrics, all_metrics
 

--- a/src/silvimetric/commands/extract.py
+++ b/src/silvimetric/commands/extract.py
@@ -161,6 +161,7 @@ def extract(config: ExtractConfig) -> None:
     final = handle_overlaps(config, storage, i).sort_values(['Y', 'X'])
 
     # output metric data to tifs
+    config.log.info(f"Writing rasters to {config.out_dir}")
     for ma in ma_list:
         # TODO should output in sections so we don't run into memory problems
         m_data = np.full(shape=(ysize,xsize), fill_value=np.nan, dtype=final[ma].dtype)

--- a/src/silvimetric/commands/manage.py
+++ b/src/silvimetric/commands/manage.py
@@ -1,8 +1,16 @@
 from .. import Storage, ShatterConfig
 from .info import info
 from .shatter import shatter
+from ..resources.log import Log
 
-def delete(tdb_dir: str, name:str) -> ShatterConfig:
+def get_logger(log):
+    if log is None:
+        return Log("INFO")
+    else:
+        return log
+
+
+def delete(tdb_dir: str, name:str, log: Log=None) -> ShatterConfig:
     """
     Delete Shatter process from database and return config for that process.
 
@@ -12,6 +20,9 @@ def delete(tdb_dir: str, name:str) -> ShatterConfig:
     :raises ValueError: Shatter process with ID is missing a time reservation
     :return: Config of process that was deleted.
     """
+
+    logger = get_logger(log)
+
     res = info(tdb_dir=tdb_dir, name=name)
 
     try:
@@ -25,9 +36,11 @@ def delete(tdb_dir: str, name:str) -> ShatterConfig:
         raise ValueError(f'Shatter process with ID {name} is missing a time reservation.')
 
     storage = Storage.from_db(tdb_dir)
+
+    logger.info(f"Deleting task {name}.")
     return storage.delete(time_slot)
 
-def restart(tdb_dir: str, name: str) -> int:
+def restart(tdb_dir: str, name: str, log: Log=None) -> int:
     """
     Delete shatter process from database and run it again with the same config.
 
@@ -36,10 +49,13 @@ def restart(tdb_dir: str, name: str) -> int:
     :return: Point count of the restarted shatter process.
     """
 
+    logger = get_logger(log)
+
     cfg = delete(tdb_dir, name)
+    logger.info(f"Restarting task {name} with same config.")
     return shatter(cfg)
 
-def resume(tdb_dir: str, name: str) -> int:
+def resume(tdb_dir: str, name: str, log: Log=None) -> int:
     """
     Resume partially completed shatter process. Process must partially completed
     and have an already established time slot.
@@ -48,6 +64,10 @@ def resume(tdb_dir: str, name: str) -> int:
     :param name: UUID name of Shatter process.
     :return: Point count of the restarted shatter process.
     """
+
+    logger = get_logger(log)
+
+    logger.info(f"Resuming task {name}.")
     res = info(tdb_dir=tdb_dir, name=name)
     assert len(res['history']) == 1
     config = res['history'][0]

--- a/src/silvimetric/commands/shatter.py
+++ b/src/silvimetric/commands/shatter.py
@@ -241,10 +241,6 @@ def shatter(config: ShatterConfig) -> int:
     config.log.debug(f'Data: {str(data)}')
     config.log.debug(f'Extents: {str(extents)}')
 
-    if get_client() is None:
-        config.log.warning("Selected scheduler type does not support"
-            "continuously updated config information.")
-
     if not config.time_slot: # defaults to 0, which is reserved for storage cfg
         config.time_slot = storage.reserve_time_slot()
 

--- a/src/silvimetric/commands/shatter.py
+++ b/src/silvimetric/commands/shatter.py
@@ -230,9 +230,9 @@ def shatter(config: ShatterConfig) -> int:
     :return: Number of points processed.
     """
 
-    if get_client() is None:
-        config.log.logger.error("Dask distributed scheduler is currently disabled"
-            "for SilviMetric.")
+    if get_client() is not None:
+        raise AttributeError("Dask distributed scheduler is currently disabled "
+            "for SilviMetric. Use a different scheduler to continue.")
 
     # get start time in milliseconds
     config.start_time = datetime.datetime.now().timestamp() * 1000

--- a/src/silvimetric/commands/shatter.py
+++ b/src/silvimetric/commands/shatter.py
@@ -229,6 +229,11 @@ def shatter(config: ShatterConfig) -> int:
     :param config: :class:`silvimetric.resources.config.ShatterConfig`.
     :return: Number of points processed.
     """
+
+    if get_client() is None:
+        config.log.logger.error("Dask distributed scheduler is currently disabled"
+            "for SilviMetric.")
+
     # get start time in milliseconds
     config.start_time = datetime.datetime.now().timestamp() * 1000
     # set up tiledb

--- a/src/silvimetric/commands/shatter.py
+++ b/src/silvimetric/commands/shatter.py
@@ -12,9 +12,11 @@ from dask.delayed import Delayed
 import dask.array as da
 import dask.bag as db
 from dask.diagnostics import ProgressBar
+from line_profiler import profile
 
 from .. import Extents, Storage, Data, ShatterConfig, run_metrics
 
+@profile
 def get_data(extents: Extents, filename: str, storage: Storage):
     """
     Execute pipeline and retrieve point cloud data for this extent
@@ -29,6 +31,7 @@ def get_data(extents: Extents, filename: str, storage: Storage):
     data.execute()
     return p.get_dataframe(0)
 
+@profile
 def arrange(points: pd.DataFrame, leaf, attrs: list[str]):
     """
     Arrange data to fit key-value TileDB input format.
@@ -58,6 +61,7 @@ def arrange(points: pd.DataFrame, leaf, attrs: list[str]):
 
     return points
 
+@profile
 def get_metrics(data_in, storage: Storage):
     """
     Run DataFrames through metric processes
@@ -67,6 +71,7 @@ def get_metrics(data_in, storage: Storage):
 
     return run_metrics(data_in, storage.config.metrics)
 
+@profile
 def agg_list(data_in):
     """
     Make variable-length point data attributes into lists
@@ -90,6 +95,7 @@ def agg_list(data_in):
     a = coerced.groupby(['xi','yi']).agg(lambda x: np.array(x, old_dtypes[x.name]))
     return a.assign(count=lambda x: [len(z) for z in a.Z])
 
+@profile
 def join(list_data: pd.DataFrame, metric_data):
     """
     Join the list data and metric DataFrames together.
@@ -102,6 +108,7 @@ def join(list_data: pd.DataFrame, metric_data):
 
     return list_data.join(metric_data).reset_index()
 
+@profile
 def write(data_in, storage, timestamp):
     """
     Write cell data to database

--- a/src/silvimetric/commands/shatter.py
+++ b/src/silvimetric/commands/shatter.py
@@ -12,11 +12,9 @@ from dask.delayed import Delayed
 import dask.array as da
 import dask.bag as db
 from dask.diagnostics import ProgressBar
-from line_profiler import profile
 
 from .. import Extents, Storage, Data, ShatterConfig, run_metrics
 
-@profile
 def get_data(extents: Extents, filename: str, storage: Storage):
     """
     Execute pipeline and retrieve point cloud data for this extent
@@ -31,7 +29,6 @@ def get_data(extents: Extents, filename: str, storage: Storage):
     data.execute()
     return p.get_dataframe(0)
 
-@profile
 def arrange(points: pd.DataFrame, leaf, attrs: list[str]):
     """
     Arrange data to fit key-value TileDB input format.
@@ -61,7 +58,6 @@ def arrange(points: pd.DataFrame, leaf, attrs: list[str]):
 
     return points
 
-@profile
 def get_metrics(data_in, storage: Storage):
     """
     Run DataFrames through metric processes
@@ -71,7 +67,6 @@ def get_metrics(data_in, storage: Storage):
 
     return run_metrics(data_in, storage.config.metrics)
 
-@profile
 def agg_list(data_in):
     """
     Make variable-length point data attributes into lists
@@ -95,7 +90,6 @@ def agg_list(data_in):
     a = coerced.groupby(['xi','yi']).agg(lambda x: np.array(x, old_dtypes[x.name]))
     return a.assign(count=lambda x: [len(z) for z in a.Z])
 
-@profile
 def join(list_data: pd.DataFrame, metric_data):
     """
     Join the list data and metric DataFrames together.
@@ -108,7 +102,6 @@ def join(list_data: pd.DataFrame, metric_data):
 
     return list_data.join(metric_data).reset_index()
 
-@profile
 def write(data_in, storage, timestamp):
     """
     Write cell data to database

--- a/src/silvimetric/resources/data.py
+++ b/src/silvimetric/resources/data.py
@@ -220,6 +220,9 @@ class Data:
         :return: estimated point count
         """
 
+        # TODO: if bounds is different from root bounds, find way to estimate
+        # point count. PDAL quickinfo grabs info from header or ept.json
+        # and this reflects point count of entire file
         reader = self.get_reader()
         if bounds:
             reader._options['bounds'] = str(bounds)

--- a/src/silvimetric/resources/metric.py
+++ b/src/silvimetric/resources/metric.py
@@ -16,7 +16,6 @@ import dask
 from dask.delayed import Delayed
 from distributed import Future
 from .attribute import Attribute
-from line_profiler import profile
 
 MetricFn = Callable[[pd.DataFrame, Any], pd.DataFrame]
 FilterFn = Callable[[pd.DataFrame, Optional[Union[Any, None]]], pd.DataFrame]
@@ -89,7 +88,6 @@ class Metric():
         """Name for use in TileDB and extract file generation."""
         return f'm_{attr}_{self.name}'
 
-    @profile
     def sanitize_and_run(self, d, locs, args):
         # Args are the return values of previous DataFrame aggregations.
         # In order to access the correct location, we need a map of groupby
@@ -111,7 +109,6 @@ class Metric():
 
         return self._method(d, *pass_args)
 
-    @profile
     def do(self, data: pd.DataFrame, *args) -> pd.DataFrame:
         """Run metric and filters. Use previously run metrics to avoid running
         the same thing multiple times."""

--- a/src/silvimetric/resources/metric.py
+++ b/src/silvimetric/resources/metric.py
@@ -131,6 +131,7 @@ class Metric():
             data = data[attrs]
 
         data = self.run_filters(data)
+        idxer = data[idx]
         gb = data.groupby(idx)
 
         def merge(left, right):
@@ -144,7 +145,7 @@ class Metric():
 
         # create map of current column name to tuple of new column name and metric method
         cols = data.columns
-        runner = lambda d: self.sanitize_and_run(d, data[idx], merged_args)
+        runner = lambda d: self.sanitize_and_run(d, idxer, merged_args)
 
         prev_cols = [col for col in cols if col not in idx]
 

--- a/src/silvimetric/resources/metrics/l_moments.py
+++ b/src/silvimetric/resources/metrics/l_moments.py
@@ -1,32 +1,27 @@
 from ..metric import Metric
 import numpy as np
-from .p_moments import mean
-from lmoments3 import lmom_ratios
 from lmoments3 import distr
 
 import warnings
-# suppress warnings from dividing by 0, these are handled in the metric creation
-warnings.filterwarnings(
-    action='ignore',
-    category=RuntimeWarning,
-    module='lmoments3'
-)
 
 def lmom4(data):
-    n = data.count()
-    try:
-        paras = distr.gam.lmom_fit(data)
-        if n < 1:
-            return [np.nan, np.nan, np.nan, np.nan]
-        elif n < 2:
-            return [data.mean, np.nan, np.nan, np.nan]
-        elif n < 3:
-            return [*distr.gam.lmom(nmom=2, **paras), np.nan, np.nan, np.nan]
-        elif n < 4:
-            return [*distr.gam.lmom(nmom=3, **paras), np.nan, np.nan, np.nan]
-        return [*distr.gam.lmom(nmom=4, **paras)]
-    except:
-        return [data.mean(), np.nan, np.nan, np.nan]
+    # suppress warnings from dividing by 0, these are handled in the metric creation
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', category=RuntimeWarning)
+        n = data.count()
+        try:
+            paras = distr.gam.lmom_fit(data)
+            if n < 1:
+                return [np.nan, np.nan, np.nan, np.nan]
+            elif n < 2:
+                return [data.mean, np.nan, np.nan, np.nan]
+            elif n < 3:
+                return [*distr.gam.lmom(nmom=2, **paras), np.nan, np.nan, np.nan]
+            elif n < 4:
+                return [*distr.gam.lmom(nmom=3, **paras), np.nan, np.nan, np.nan]
+            return [*distr.gam.lmom(nmom=4, **paras)]
+        except:
+            return [data.mean(), np.nan, np.nan, np.nan]
 
 # L1 is same as mean...compute using np.mean for speed
 def m_l1(data, *args):

--- a/src/silvimetric/resources/metrics/l_moments.py
+++ b/src/silvimetric/resources/metrics/l_moments.py
@@ -4,6 +4,8 @@ from lmoments3 import distr
 
 import warnings
 
+# TODO: provide link to documentation on L-Moments
+
 def lmom4(data):
     # suppress warnings from dividing by 0, these are handled in the metric creation
     with warnings.catch_warnings():
@@ -23,7 +25,7 @@ def lmom4(data):
         except:
             return [data.mean(), np.nan, np.nan, np.nan]
 
-# L1 is same as mean...compute using np.mean for speed
+# L1 is same as mean...computed using np.mean in L-moment base for speed
 def m_l1(data, *args):
     return args[0][0]
 

--- a/src/silvimetric/resources/metrics/p_moments.py
+++ b/src/silvimetric/resources/metrics/p_moments.py
@@ -1,5 +1,6 @@
 import numpy as np
 from scipy.stats import moment
+from line_profiler import profile
 
 from ..metric import Metric
 
@@ -7,6 +8,7 @@ def m_moments(data, *args):
     mean = args[0]
     return moment(data, center=mean, order=[2,3,4], nan_policy='omit').tolist()
 
+@profile
 def m_mean(data, *args):
     return np.mean(data)
 

--- a/src/silvimetric/resources/metrics/p_moments.py
+++ b/src/silvimetric/resources/metrics/p_moments.py
@@ -1,14 +1,12 @@
 import numpy as np
 from scipy.stats import moment
-from line_profiler import profile
 
 from ..metric import Metric
 
 def m_moments(data, *args):
     mean = args[0]
-    return moment(data, center=mean, order=[2,3,4], nan_policy='omit').tolist()
+    return moment(data, center=mean, order=[2,3,4], nan_policy='propagate').tolist()
 
-@profile
 def m_mean(data, *args):
     return np.mean(data)
 

--- a/src/silvimetric/resources/metrics/p_moments.py
+++ b/src/silvimetric/resources/metrics/p_moments.py
@@ -1,11 +1,17 @@
 import numpy as np
 from scipy.stats import moment
+import warnings
 
 from ..metric import Metric
 
+
 def m_moments(data, *args):
     mean = args[0]
-    return moment(data, center=mean, order=[2,3,4], nan_policy='propagate').tolist()
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', category=RuntimeWarning)
+        m = moment(data, center=mean, order=[2,3,4], nan_policy='propagate').tolist()
+
+    return m
 
 def m_mean(data, *args):
     return np.mean(data)

--- a/src/silvimetric/resources/metrics/stats.py
+++ b/src/silvimetric/resources/metrics/stats.py
@@ -4,8 +4,6 @@ from ..metric import Metric
 from .p_moments import mean
 from .percentiles import pct_base
 
-from line_profiler import profile
-
 import warnings
 # suppress warnings from dividing by 0, these are handled in the metric creation
 warnings.filterwarnings(
@@ -23,11 +21,9 @@ def m_mode(data):
 def m_median(data, *args):
     return np.median(data)
 
-@profile
 def m_min(data, *args):
     return np.min(data)
 
-@profile
 def m_max(data, *args):
     return np.max(data)
 

--- a/src/silvimetric/resources/metrics/stats.py
+++ b/src/silvimetric/resources/metrics/stats.py
@@ -4,6 +4,8 @@ from ..metric import Metric
 from .p_moments import mean
 from .percentiles import pct_base
 
+from line_profiler import profile
+
 import warnings
 # suppress warnings from dividing by 0, these are handled in the metric creation
 warnings.filterwarnings(
@@ -21,9 +23,11 @@ def m_mode(data):
 def m_median(data, *args):
     return np.median(data)
 
+@profile
 def m_min(data, *args):
     return np.min(data)
 
+@profile
 def m_max(data, *args):
     return np.max(data)
 

--- a/tests/fixtures/metric_fixtures.py
+++ b/tests/fixtures/metric_fixtures.py
@@ -100,10 +100,10 @@ def depless_crr():
 @pytest.fixture
 def dep_crr():
     def m_crr_2(data, *args):
-        mean, minimum, maximum = args
-        den = (maximum - minimum)
+        m, mi, ma = args
+        den = (ma- mi)
         if den == 0:
             return np.nan
-        return (mean - minimum) / den
+        return (m - mi) / den
 
     return Metric('deps_crr', np.float32, m_crr_2, [mean, sm_min, sm_max])

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,3 +1,4 @@
+import pytest
 import json
 
 from silvimetric.commands import scan, info, shatter, manage
@@ -50,18 +51,26 @@ class TestCommands(object):
         h = info.info(tdb_dir=tdb_filepath)
         assert not bool(h['history'])
 
-    def test_311_failure(self, shatter_config, dask_proc_client):
-        # make sure we handle tiledb contexts correctly within dask
+    def test_distributed_fail(self, shatter_config, dask_proc_client):
+        # make sure we handle when a distributed dask is passed to shatter
+        match_str = ("Dask distributed scheduler is currently disabled for "
+            "SilviMetric. Use a different scheduler to continue.")
+        with pytest.raises(AttributeError, match=match_str):
+            shatter.shatter(shatter_config)
 
-        tdb_dir = shatter_config.tdb_dir
-        shatter.shatter(shatter_config)
+    # TODO: reactivate when dask distributed is no longer disabled
+    # def test_311_failure(self, shatter_config, dask_proc_client):
+    #     # make sure we handle tiledb contexts correctly within dask
 
-        i = info.info(tdb_dir)
-        history = i['history'][-1]
+    #     tdb_dir = shatter_config.tdb_dir
+    #     shatter.shatter(shatter_config)
 
-        finished_config = ShatterConfig.from_dict(history)
-        sh_id = finished_config.name
-        manage.delete(tdb_dir, sh_id)
+    #     i = info.info(tdb_dir)
+    #     history = i['history'][-1]
+
+    #     finished_config = ShatterConfig.from_dict(history)
+    #     sh_id = finished_config.name
+    #     manage.delete(tdb_dir, sh_id)
 
     def test_restart(self, tdb_filepath, config_split):
         ids = [c.name for c in config_split]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -95,3 +95,10 @@ class TestMetrics():
         assert b.m_Z_over500.any()
         assert b.m_Z_over500.values[0] == 3
 
+    def test_dependency_passing(dep_crr, depless_crr, metric_data):
+        nd1 = run_metrics(metric_data, depless_crr).compute()
+        nd2 = run_metrics(metric_data, dep_crr).compute()
+        print(nd1)
+        print(nd2)
+        assert False
+        # assert new_m_data.m_Z_deps_crr == new_m_data.m_Z_depless_crr

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -2,7 +2,6 @@ import numpy as np
 import pandas as pd
 
 from silvimetric import shatter, Storage, grid_metrics, run_metrics, Metric
-from silvimetric.resources.metrics.stats import crr
 from silvimetric import all_metrics as s
 from silvimetric import l_moments
 from silvimetric.resources.attribute import Attribute

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 
 from silvimetric import shatter, Storage, grid_metrics, run_metrics, Metric
+from silvimetric.resources.metrics.stats import crr
 from silvimetric import all_metrics as s
 from silvimetric import l_moments
 from silvimetric.resources.attribute import Attribute
@@ -95,10 +96,7 @@ class TestMetrics():
         assert b.m_Z_over500.any()
         assert b.m_Z_over500.values[0] == 3
 
-    def test_dependency_passing(dep_crr, depless_crr, metric_data):
+    def test_dependency_passing(self, dep_crr, depless_crr, metric_data):
         nd1 = run_metrics(metric_data, depless_crr).compute()
         nd2 = run_metrics(metric_data, dep_crr).compute()
-        print(nd1)
-        print(nd2)
-        assert False
-        # assert new_m_data.m_Z_deps_crr == new_m_data.m_Z_depless_crr
+        assert all(nd2.m_Z_deps_crr == nd1.m_Z_depless_crr)


### PR DESCRIPTION
Dependencies, updated in #91, output a pandas dataframe housing the computed metrics. These dataframes are then passed to the dependent metrics down the line, such that a metric like `crr`, which has dependencies `mean, min, and max`, had an `*args` input like `[mean_dataframe, min_dataframe, max_dataframe]`. Metric class was incorrectly selecting a static location in this dataframe array, so all dependent metrics were using the same input. 

This is fixed by passing the `index` of the dataframe into the aggregation method as well, which allows us to select the correct `cell index`, which we then use to select the correct data passed in.

This PR also addresses some environment issues, and pins an upper and lower bounds for python, as well as a lower bounds for a more recent dask installation, which I think was causing #105. To make sure these environments are accounted for, an update to the workflow file with a matrix of python versions has been added as well, so each environment should be tested with 3.10-3.12.

*** Note: Dask Distributed will be disabled in conjunction with silvimetric for this release. Something in the way the flow has been set up does not agree with dask, so it will be disabled for now. *** 