### PR TITLE
1.4.1

### DIFF
--- a/src/silvimetric/__init__.py
+++ b/src/silvimetric/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.3.1'
+__version__ = '1.4.0'
 
 from .resources.bounds import Bounds
 from .resources.extents import Extents

--- a/src/silvimetric/__init__.py
+++ b/src/silvimetric/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.4.0'
+__version__ = '1.4.1'
 
 from .resources.bounds import Bounds
 from .resources.extents import Extents

--- a/src/silvimetric/cli/common.py
+++ b/src/silvimetric/cli/common.py
@@ -136,7 +136,7 @@ class MetricParamType(click.ParamType):
                     elif val == 'aad':
                         metrics.update(list(aad.aad.values()))
                     elif val == 'grid_metrics':
-                        metrics.update(list(grid_metrics.values()))
+                        metrics.update(list(grid_metrics.get_grid_metrics().values()))
                     elif val == 'all':
                         metrics.update(list(all_metrics.values()))
                     else:
@@ -158,7 +158,6 @@ def dask_handle(
     workers: int,
     threads: int,
     watch: bool,
-    log: Log,
 ) -> None:
     dask_config = {}
 

--- a/src/silvimetric/commands/info.py
+++ b/src/silvimetric/commands/info.py
@@ -99,5 +99,10 @@ def info(
             info['history'] = history
         except KeyError:
             history = {}
+    # remove unnecessary keys for printing to logs
+    if concise:
+        info['metadata'].pop('attrs')
+        info['metadata'].pop('debug')
+        info['metadata'].pop('log')
 
     return info

--- a/src/silvimetric/resources/bounds.py
+++ b/src/silvimetric/resources/bounds.py
@@ -127,9 +127,12 @@ class Bounds(dict):  # for JSON serializing
         :param other: Bounds this object is being compared to
         :return: True if this box shares no point with the other
         """
-        if other.minx > self.maxx or other.maxx < self.minx:
+        # disjoint varies minorly from normal because we don't use points
+        # on the maxx or maxy lines, so they can be equal to the min vals
+        # and stil functionally disjoint
+        if other.minx >= self.maxx or other.maxx <= self.minx:
             return True
-        if other.miny > self.maxy or other.maxy < self.miny:
+        if other.miny >= self.maxy or other.maxy <= self.miny:
             return True
         return False
 

--- a/src/silvimetric/resources/config.py
+++ b/src/silvimetric/resources/config.py
@@ -1,5 +1,6 @@
 import pyproj
 
+import os
 import json
 import uuid
 
@@ -33,7 +34,14 @@ class Config(ABC):
         keys = self.__dataclass_fields__.keys()
         d = {}
         for k in keys:
-            d[k] = self.__dict__[k]
+            if k == 'tdb_dir':
+                tdb_dir = self.__dict__[k]
+                if "://" not in tdb_dir:
+                    d[k] = os.path.abspath(tdb_dir)
+                else:
+                    d[k] = tdb_dir
+            else:
+                d[k] = self.__dict__[k]
         if not isinstance(d['log'], dict):
             d['log'] = d['log'].to_json()
         return d

--- a/src/silvimetric/resources/config.py
+++ b/src/silvimetric/resources/config.py
@@ -227,7 +227,7 @@ class ShatterConfig(Config):
 
     filename: str
     """Input filename referencing a PDAL pipeline or point cloud file."""
-    date: Union[datetime, Tuple[datetime, datetime]]
+    date: Union[Tuple[datetime, datetime]]
     """A date or date range representing data collection times."""
     bounds: Union[Bounds, None] = field(default=None)
     """The bounding box of the shatter process., defaults to None"""
@@ -257,6 +257,12 @@ class ShatterConfig(Config):
         from .storage import Storage
 
         s = Storage.from_db(self.tdb_dir)
+        if isinstance(self.date, datetime):
+            self.date = (self.date, self.date)
+        if len(self.date) > 2 or len(self.date) < 1:
+            raise ValueError('Date range for must be either 1 or 2 values.')
+        if len(self.date) == 1:
+            self.date = (self.date[0], self.date[0])
 
         if isinstance(self.tile_size, float):
             self.tile_size = int(self.tile_size)
@@ -271,10 +277,10 @@ class ShatterConfig(Config):
         # removing a attrs and metrics, since they'll be in the storage log
         # removing mbr because it's too big to do json pretty printing with
         # could add a custom json logger to handle mbr logging in the future
-        if isinstance(self.date, tuple):
-            date = [dt.strftime('%Y-%m-%dT%H:%M:%SZ') for dt in self.date]
-        else:
-            date = self.date.strftime('%Y-%m-%dT%H:%M:%SZ')
+        date = (
+            self.date[0].strftime('%Y-%m-%dT%H:%M:%SZ'),
+            self.date[1].strftime('%Y-%m-%dT%H:%M:%SZ'),
+        )
         d = dict(
             filename=self.filename,
             name=str(self.name),

--- a/src/silvimetric/resources/extents.py
+++ b/src/silvimetric/resources/extents.py
@@ -59,14 +59,10 @@ class Extents(object):
 
         :return: Indices of this bounding box
         """
-        return np.array(
-            [
-                (i, j)
-                for i in range(self.x1, self.x2)
-                for j in range(self.y1, self.y2)
-            ],
-            dtype=[('x', np.int32), ('y', np.int32)],
-        )
+        xis = np.arange(self.x1, self.x2, dtype=np.int32)
+        yis = np.arange(self.y1, self.y2, dtype=np.int32)
+        xys = np.array(np.meshgrid(xis,yis)).T.reshape(-1,2)
+        return xys
 
     def disjoint_by_mbr(self, mbr):
         """

--- a/src/silvimetric/resources/metrics/aad.py
+++ b/src/silvimetric/resources/metrics/aad.py
@@ -1,7 +1,7 @@
 import numpy as np
-from scipy import stats
 from ..metric import Metric
-from .p_moments import product_moments
+from .p_moments import product_moments, mean
+from .stats import mode, median
 
 
 def m_aad(data, *args):
@@ -10,23 +10,26 @@ def m_aad(data, *args):
 
 
 def m_madmedian(data, *args):
-    return stats.median_abs_deviation(data)
+    median = args[0]
+    return np.median(abs(data - median))
 
 
 def m_madmean(data, *args):
-    return stats.median_abs_deviation(data, center=np.mean)
+    mean = args[0]
+    return np.median(abs(data - mean))
 
 
-def m_madmode(data):
-    def mode_center(data, axis):
-        return stats.mode(data, axis=axis).mode
-
-    return stats.median_abs_deviation(data, center=mode_center)
+def m_madmode(data, *args):
+    mode = args[0]
+    return np.median(abs(data - mode))
 
 
 aad: dict[str, Metric] = {}
 aad['aad'] = Metric(
     'aad', np.float32, m_aad, dependencies=[product_moments['mean']]
 )
-aad['mad_median'] = Metric('mad_median', np.float32, m_madmedian)
-aad['mad_mode'] = Metric('mad_mode', np.float32, m_madmode)
+aad['mad_median'] = Metric(
+    'mad_median', np.float32, m_madmedian, dependencies=[median]
+)
+aad['mad_mode'] = Metric('mad_mode', np.float32, m_madmode, dependencies=[mode])
+aad['mad_mean'] = Metric('mad_mean', np.float32, m_madmean, dependencies=[mean])

--- a/src/silvimetric/resources/metrics/covers.py
+++ b/src/silvimetric/resources/metrics/covers.py
@@ -8,14 +8,14 @@ from .counts import first_returns_filter, get_count_metrics
 ##### Methods ######
 def cover_fn(data, *args):
     count = args[0]
-    return data.count() / count * 100
-
-def cover_fn2(data, *args):
-    count = args[0]
+    if count == 0:
+        return np.nan
     return data.count() / count * 100
 
 def cover_above_val(data, *args):
     count = args[0]
+    if data.count() == 0:
+        return np.nan
     return count / data.count() * 100
 
 
@@ -50,7 +50,7 @@ def get_cover_metrics(elev_key='Z'):
     first_cover = Metric(
         '1st_cover_above_htbreak',
         np.float32,
-        cover_fn2,
+        cover_fn,
         dependencies=[counts['1st_count']],
         filters=[first_returns_filter],
         attributes=[A['ReturnNumber']],

--- a/src/silvimetric/resources/metrics/grid_metrics.py
+++ b/src/silvimetric/resources/metrics/grid_metrics.py
@@ -71,6 +71,7 @@ def _get_grid_metrics(elev_key='Z'):
 
     aad['aad'].attributes = [A[elev_key], A['Intensity']]
     aad['mad_median'].attributes = [A[elev_key]]
+    aad['mad_mean'].attributes = [A[elev_key]]
     aad['mad_mode'].attributes = [A[elev_key]]
 
     grid_metrics: dict[str, Metric] = dict(

--- a/src/silvimetric/resources/metrics/l_moments.py
+++ b/src/silvimetric/resources/metrics/l_moments.py
@@ -75,6 +75,8 @@ def m_lcv(data, *args):
     lmom: tuple[float, float, float, float] = args[0]
 
     try:
+        if lmom[0] == 0:
+            return np.nan
         return lmom[1] / lmom[0]
     except ZeroDivisionError:
         return np.nan
@@ -83,6 +85,8 @@ def m_lcv(data, *args):
 def m_lskewness(data, *args):
     lmom: tuple[float, float, float, float] = args[0]
     try:
+        if lmom[1] == 0:
+            return np.nan
         return lmom[2] / lmom[1]
     except ZeroDivisionError:
         return np.nan
@@ -91,6 +95,8 @@ def m_lskewness(data, *args):
 def m_lkurtosis(data, *args):
     lmom: tuple[float, float, float, float] = args[0]
     try:
+        if lmom[1] == 0:
+            return np.nan
         return lmom[3] / lmom[1]
     except ZeroDivisionError:
         return np.nan

--- a/src/silvimetric/resources/metrics/p_moments.py
+++ b/src/silvimetric/resources/metrics/p_moments.py
@@ -4,27 +4,37 @@ from ..metric import Metric
 
 
 def m_mean(data, *args):
-    m = np.mean(data)
+    m = data.mean()
+    if m.size == 0:
+        return np.nan
     return m
 
 
 def m_variance(data, *args):
     # copy FUSION's variance approach
-    return ((data - data.mean()) ** 2).sum() / (data.count() - 1)
+    num = ((data - data.mean()) ** 2).sum()
+    denom = (data.count() - 1)
+    if denom == 0:
+        return np.nan
+    return num / denom
 
 
 def m_skewness(data, *args):
     # copy FUSION's approximation of skewness
-    return ((data - data.mean()) ** 3).sum() / (
-        (data.count() - 1) * np.std(data) ** 3
-    )
+    num = ((data - data.mean()) ** 3).sum()
+    denom = ( (data.count() - 1) * np.std(data) ** 3)
+    if denom == 0:
+        return np.nan
+    return  num / denom
 
 
 def m_kurtosis(data, *args):
     # copy FUSION's approximation of kurtosis
-    return ((data - data.mean()) ** 4).sum() / (
-        (data.count() - 1) * np.std(data) ** 4
-    )
+    num = ((data - data.mean()) ** 4).sum()
+    denom = ((data.count() - 1) * np.std(data) ** 4)
+    if denom == 0:
+        return np.nan
+    return num / denom
 
 
 mean = Metric(name='mean', dtype=np.float32, method=m_mean)

--- a/src/silvimetric/resources/metrics/stats.py
+++ b/src/silvimetric/resources/metrics/stats.py
@@ -9,9 +9,15 @@ def m_mode(data, *args):
     # split into 64 bins, return highest bin count
     # if there is a tie, return first entry (lowest bin index)
 
-    counts, bins = np.histogram(data, 64, range=(data.min(), data.max()))
+    try:
+        counts, bins = np.histogram(data, 64)
+    except ValueError:
+        try:
+            counts, bins = np.histogram(data)
+        except ValueError:
+            return np.nan
     mode = bins[:-1][counts == counts.max()]
-    return mode[0].item()
+    return mode[0]
 
 
 def m_median(data, *args):

--- a/src/silvimetric/resources/storage.py
+++ b/src/silvimetric/resources/storage.py
@@ -1,11 +1,9 @@
-import os
 import tiledb
 import numpy as np
 from datetime import datetime
 import pathlib
 import contextlib
 import json
-import urllib
 from typing_extensions import Generator, Optional
 
 from math import floor
@@ -18,7 +16,7 @@ from .bounds import Bounds
 class Storage:
     """Handles storage of shattered data in a TileDB Database."""
 
-    def __init__(self, config: StorageConfig, ctx: tiledb.Ctx = None):
+    def __init__(self, config: StorageConfig):
         if not tiledb.object_type(config.tdb_dir) == 'array':
             raise Exception(
                 f"Given database directory '{config.tdb_dir}' does not exist"
@@ -57,7 +55,7 @@ class Storage:
 
         # TODO make any changes to tiledb setup here.
 
-        if not ctx:
+        if ctx is None:
             ctx = tiledb.default_ctx()
 
         # adjust cell bounds if necessary
@@ -70,8 +68,8 @@ class Storage:
             (config.root.maxy - config.root.miny) / float(config.resolution)
         )
 
-        dim_row = tiledb.Dim(name='X', domain=(0, xi), dtype=np.int32)
-        dim_col = tiledb.Dim(name='Y', domain=(0, yi), dtype=np.int32)
+        dim_row = tiledb.Dim(name='X', domain=(0, xi), dtype=np.float64)
+        dim_col = tiledb.Dim(name='Y', domain=(0, yi), dtype=np.float64)
         domain = tiledb.Domain(dim_row, dim_col)
 
         count_att = tiledb.Attr(name='count', dtype=np.int32)
@@ -113,20 +111,23 @@ class Storage:
             meta = str(config)
             a.meta['config'] = meta
 
-        s = Storage(config, ctx)
+        s = Storage(config)
         s.saveConfig()
 
         return s
 
     @staticmethod
-    def from_db(tdb_dir: str):
+    def from_db(tdb_dir: str, ctx: tiledb.Ctx=None):
         """
         Create Storage object from information stored in a database.
 
         :param tdb_dir: TileDB database directory.
         :return: Returns the derived storage.
         """
-        with tiledb.open(tdb_dir, 'r') as a:
+        if ctx is None:
+            ctx = tiledb.default_ctx()
+
+        with tiledb.open(tdb_dir, 'r', ctx=ctx) as a:
             s = a.meta['config']
             config = StorageConfig.from_string(s)
 
@@ -151,7 +152,7 @@ class Storage:
 
         return config
 
-    def getMetadata(self, key: str, timestamp: int) -> str:
+    def getMetadata(self, key: str, timestamp: Optional[int] = None) -> str:
         """
         Return metadata at given key.
 
@@ -159,22 +160,29 @@ class Storage:
         :param timestamp: Time stamp for querying database.
         :return: Metadata value found in storage.
         """
-
+        if timestamp is None:
+            with self.open('r') as r:
+                val = r.meta[f'{key}']
         with self.open('r', (timestamp, timestamp)) as r:
             val = r.meta[f'{key}']
 
         return val
 
-    def saveMetadata(self, key: str, data: str, timestamp: int) -> None:
+    def saveMetadata(
+        self, key: str, data: str, timestamp: Optional[int] = None, retries=0
+    ) -> None:
         """
         Save metadata to storage.
 
         :param key: Metadata key to save to.
         :param data: Data to save to metadata.
         """
-        with self.open('w', (timestamp, timestamp)) as w:
-            w.meta[f'{key}'] = data
-        return
+        if timestamp is None:
+            with self.open('w') as w:
+                w.meta[f'{key}'] = data
+        else:
+            with self.open('w', (timestamp, timestamp)) as w:
+                w.meta[f'{key}'] = data
 
     def getAttributes(self) -> list[Attribute]:
         """
@@ -250,13 +258,13 @@ class Storage:
 
         :return: Time slot.
         """
-        with tiledb.open(self.config.tdb_dir, 'r') as r:
+        with self.open('r') as r:
             latest = json.loads(r.meta['config'])
 
         time = latest['next_time_slot']
         latest['next_time_slot'] = time + 1
 
-        with tiledb.open(self.config.tdb_dir, 'w') as w:
+        with self.open('w') as w:
             w.meta['config'] = json.dumps(latest)
 
         return time
@@ -383,12 +391,9 @@ class Storage:
         :param proc_num: Time slot associated with shatter process.
         """
         try:
-            afs = self.get_fragments_by_time(proc_num)
-            uris = [
-                os.path.split(urllib.parse.urlparse(f.uri).path)[-1]
-                for f in afs
-            ]
-            tiledb.consolidate(self.config.tdb_dir, fragment_uris=uris)
+            tiledb.consolidate(
+                self.config.tdb_dir, timestamp=(proc_num, proc_num)
+            )
             c = tiledb.Config({'sm.vacuum.mode': 'fragments'})
             tiledb.vacuum(self.config.tdb_dir, c)
             self.config.log.info(f'Consolidated time slot {proc_num}.')

--- a/src/silvimetric/resources/storage.py
+++ b/src/silvimetric/resources/storage.py
@@ -73,6 +73,12 @@ class Storage:
         domain = tiledb.Domain(dim_row, dim_col)
 
         count_att = tiledb.Attr(name='count', dtype=np.int32)
+        start_dt_att = tiledb.Attr(
+            name='start_datetime', dtype=np.datetime64('', 's').dtype
+        )
+        end_dt_att = tiledb.Attr(
+            name='end_datetime', dtype=np.datetime64('', 's').dtype
+        )
         dim_atts = [attr.schema() for attr in config.attrs]
 
         metric_atts = [
@@ -100,7 +106,7 @@ class Storage:
         schema = tiledb.ArraySchema(
             domain=domain,
             sparse=True,
-            attrs=[count_att, *dim_atts, *metric_atts],
+            attrs=[count_att, start_dt_att, end_dt_att, *dim_atts, *metric_atts],
             allows_duplicates=True,
             capacity=1000,
         )
@@ -117,7 +123,7 @@ class Storage:
         return s
 
     @staticmethod
-    def from_db(tdb_dir: str, ctx: tiledb.Ctx=None):
+    def from_db(tdb_dir: str, ctx: tiledb.Ctx = None):
         """
         Create Storage object from information stored in a database.
 

--- a/tests/fixtures/fake_metrics.py
+++ b/tests/fixtures/fake_metrics.py
@@ -7,10 +7,13 @@ def count(data):
 
 
 def has_data(data):
-    return data.any()
+    if data.any():
+        return 1
+    else:
+        return 0
 
 
 def metrics() -> list[Metric]:
     m1 = Metric('count', np.float32, count)
-    m2 = Metric('exists', np.dtype('?'), has_data)
+    m2 = Metric('exists', np.uint8, has_data)
     return [m1, m2]

--- a/tests/fixtures/metric_fixtures.py
+++ b/tests/fixtures/metric_fixtures.py
@@ -76,6 +76,8 @@ def metric_data_results() -> Generator[pd.DataFrame, None, None]:
 
     result_bytes.seek(0)
     df = pickle.load(result_bytes)
+    df = df.reset_index()
+    df = df.set_index(['yi','xi'])
     yield df
 
 
@@ -86,6 +88,8 @@ def metric_dag_results() -> Generator[pd.DataFrame, None, None]:
     )
     result_bytes.seek(0)
     df = pickle.load(result_bytes)
+    df = df.reset_index()
+    df = df.set_index(['yi','xi'])
     yield df
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -37,7 +37,7 @@ class TestCommands(object):
         assert len(i['history']) == 1
         assert i['history'][0] == config_split[0].to_json()
 
-        d = config_split[1].date
+        d = config_split[1].date[0]
         i = info.info(tdb_filepath, start_time=d, end_time=d)
         assert len(i['history']) == 1
         assert i['history'][0] == config_split[1].to_json()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -92,9 +92,6 @@ class TestCommands(object):
     def test_resume(
         self, shatter_config: ShatterConfig, storage_config: StorageConfig
     ):
-        # test that shatter only operates on cells not in nonempty_domain
-        storage = Storage.from_db(shatter_config.tdb_dir)
-
         # if AlignToCorner, then the count is 3/4 of the total when
         #     mbr = ((0,4), (0,4)),)
         # if AlignToCenter, extents are shifted half a pixel to the right,
@@ -103,17 +100,9 @@ class TestCommands(object):
             67500.0 if storage_config.alignment == 'AlignToCorner' else 86400
         )
 
-        # if pixel is area, mbr is 75 (100-25)
-        # if pixel is point, mbr is 96 (121-25)
-        mbr_count = 75 if storage_config.alignment == 'AlignToCorner' else 96
-
         # modify shatter config
         shatter_config.tile_size = 1
         shatter_config.mbr = (((0, 4), (0, 4)),)
         # send to shatter
         pc = shatter.shatter(shatter_config)
         assert pc == partial_count
-        # check output config to see what the nonempthy_domain is
-        #   - should be only only values outside of that tuple
-        m = json.loads(storage.getMetadata('shatter', 1))
-        assert len(m['mbr']) == mbr_count

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,4 +1,5 @@
 from silvimetric import StorageConfig, ShatterConfig, ExtractConfig
+import numpy as np
 
 
 class Test_Configuration(object):
@@ -15,7 +16,7 @@ class Test_Configuration(object):
         mean = [m for m in c.metrics if m.name == 'mean']
         assert len(mean) == 1
 
-        assert int(mean[0]._method([2, 2, 2, 2])) == 2
+        assert int(mean[0]._method(np.array([2, 2, 2, 2]))) == 2
         cd = c.to_json()
         scd = storage_config.to_json()
         cd.pop('log')

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -46,17 +46,15 @@ def tif_test(extract_config):
 
         assert derived == extract_config.crs
 
-        xsize = e.x2
-        ysize = e.y2
-        assert raster.RasterXSize == xsize
-        assert raster.RasterYSize == ysize
+        xsize = raster.RasterXSize
+        ysize = raster.RasterYSize
 
         r = raster.ReadAsArray()
         assert all(
             [
-                r[y, x] == (ceil(root_maxy / resolution) - y - 1)
-                for y in range(e.y1, e.y2)
-                for x in range(e.x1, e.x2)
+                r[y, x] == (ceil(root_maxy / resolution) - y - e.y1 - 1)
+                for y in range(ysize)
+                for x in range(xsize)
             ]
         )
 

--- a/tests/test_fusion.py
+++ b/tests/test_fusion.py
@@ -15,11 +15,11 @@ class TestFusion:
     # Intensity values and Mode values are slightly off from FUSION.
     # Intensity values are scaled in FUSION, and Mode is selected slightly
     # differently, so values are expected to be off.
-    # @pytest.mark.skip()
+    @pytest.mark.skip()
     def test_against_fusion(
         self,
-        # configure_dask: None,
-        threaded_dask,
+        configure_dask: None,
+        # threaded_dask,
         plumas_shatter_config: sm.ShatterConfig,
         plumas_tif_dir: str,
         metric_map: dict,

--- a/tests/test_shatter.py
+++ b/tests/test_shatter.py
@@ -93,9 +93,9 @@ class Test_Shatter(object):
         # check that you can query results by datetime
         with storage.open('r') as a:
             a:tiledb.SparseArray
-            query_time = datetime.datetime(2009,1,1).timestamp()
+            query_time = datetime.datetime(2009,6,1).timestamp()
             q = a.query(cond=f'start_datetime >= {query_time}')
-            assert q.df[:,:]['start_datetime'].size == base ** 2
+            assert len(q.df[:,:]['start_datetime']) == base ** 2
 
         m = info(storage.config.tdb_dir)
         assert len(m['history']) == 2

--- a/tests/test_shatter.py
+++ b/tests/test_shatter.py
@@ -35,8 +35,8 @@ def confirm_one_entry(storage, maxy, base, pointcount, num_entries=1):
 
     with storage.open('r') as a:
         assert a[:, :]['Z'].shape[0] == shape
-        xdom = a.schema.domain.dim('X').domain[1]
-        ydom = a.schema.domain.dim('Y').domain[1]
+        xdom = int(a.schema.domain.dim('X').domain[1])
+        ydom = int(a.schema.domain.dim('Y').domain[1])
         assert xdom == xysize
         assert ydom == xysize
         assert a[:, :]['count'].sum() == pc
@@ -178,10 +178,10 @@ class Test_Shatter(object):
             data = a.query(attrs=['Z'], coords=True, use_arrow=False).df[:]
             data = data.set_index(['X', 'Y'])
 
-            minx = data.reset_index().X.min()
-            maxx = data.reset_index().X.max()
-            miny = data.reset_index().Y.min()
-            maxy = data.reset_index().Y.max()
+            minx = int(data.reset_index().X.min())
+            maxx = int(data.reset_index().X.max())
+            miny = int(data.reset_index().Y.min())
+            maxy = int(data.reset_index().Y.max())
 
             for xi in range(minx, maxx + 1):
                 for yi in range(miny, maxy + 1):


### PR DESCRIPTION
Maintenance PR for some random stuff that came up while trying to do a large project. Biggest changes are surrounding the extraction steps, because it was incredibly slow with large databases.

Change notes:
- updated info call
	- added metrics cli option
	- fixed history
	- removed unnecessary information from concise output
- changed consolidation to use built in methods of tiledb
- updated extract call:
	- handle_overlaps speedup
	- removed extent indexing, was too slow and could get them in other ways
- updated extent
	- indexing speedup
- updated metrics:
	- added nan_value member variable
	- added nan_policy member variable
	- added logic to handle bad return values and bad dependency values depending on nan_policy
- updated storage config to adjust a relative path to absolute for tdb dir
- adjusted aad metrics to use variables that were already created
- added nan handling to several metrics in which it was possible
- updated shatter:
	- updated config writing, added try catch so that config will be written in the event of an error, then reraise error
- remove mbr count in test_resume because new consolidation changes how mbrs are stored
- adjust test_indexing to reflect new indexing method in extent
- cropping out edges of null data on rasters affected test_sub_bounds_extract, removed the xsize and ysize check. 
- changed x and y domains to be float to match what gdal expects to see in tiledb
- adding start_datetime and end_datetime to tiledb attributes being written, in similar fashion to count
    - This will allow users to query by start and end time, with possibility in the future to add features using this this
    - This was the least invasive way to add date time querying without affecting the other systems that silvimetric has in place