### PR TITLE
protect users from going oob with tile sizes

### DIFF
--- a/src/silvimetric/resources/storage.py
+++ b/src/silvimetric/resources/storage.py
@@ -88,12 +88,14 @@ class Storage:
         )
 
         # protect user from out of bounds errors
-        xsize = min(config.xsize, xi-1)
-        ysize = min(config.ysize, yi-1)
+        xsize = min(config.xsize, xi+1)
+        ysize = min(config.ysize, yi+1)
         if xsize < config.xsize:
             config.log.warning(f'X Tile size lowered to {xsize}')
         if ysize < config.ysize:
             config.log.warning(f'Y Tile size lowered to {ysize}')
+        config.xsize = xsize
+        config.ysize = ysize
 
         dim_row = tiledb.Dim(
             name='X',

--- a/src/silvimetric/resources/storage.py
+++ b/src/silvimetric/resources/storage.py
@@ -87,18 +87,26 @@ class Storage:
             (config.root.maxy - config.root.miny) / float(config.resolution)
         )
 
+        # protect user from out of bounds errors
+        xsize = min(config.xsize, xi-1)
+        ysize = min(config.ysize, yi-1)
+        if xsize < config.xsize:
+            config.log.warning(f'X Tile size lowered to {xsize}')
+        if ysize < config.ysize:
+            config.log.warning(f'Y Tile size lowered to {ysize}')
+
         dim_row = tiledb.Dim(
             name='X',
             domain=(0, xi),
             dtype=np.uint64,
-            tile=config.xsize,
+            tile=xsize,
             filters=tiledb.FilterList([tiledb.ZstdFilter()]),
         )
         dim_col = tiledb.Dim(
             name='Y',
             domain=(0, yi),
             dtype=np.uint64,
-            tile=config.ysize,
+            tile=ysize,
             filters=tiledb.FilterList([tiledb.ZstdFilter()]),
         )
         domain = tiledb.Domain(dim_row, dim_col)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -116,7 +116,14 @@ class Test_Storage(object):
             ysize=1000
         )
 
-        Storage.create(sc)
+        s = Storage.create(sc)
+        a = s.open('r')
+
+        assert a.schema.domain.dim('X').tile == 12
+        assert s.config.xsize == 12
+        assert a.schema.domain.dim('Y').tile == 12
+        assert s.config.ysize == 12
+
 
     def test_metrics(self, storage: Storage):
         m_list = storage.get_metrics()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -3,7 +3,6 @@ import numpy as np
 import pytest
 import os
 import copy
-import datetime
 
 from silvimetric import (
     Storage,
@@ -92,6 +91,32 @@ class Test_Storage(object):
         assert isinstance(s, Storage)
 
         ms[0].dependencies = []
+
+    def test_oob_storage(
+        self,
+        tmp_path_factory,
+        metrics,
+        crs,
+        resolution,
+        attrs,
+        bounds,
+    ):
+        ms = copy.deepcopy(metrics)
+        path = tmp_path_factory.mktemp('test_tdb')
+        p = os.path.abspath(path)
+
+        sc = StorageConfig(
+            tdb_dir=p,
+            crs=crs,
+            resolution=resolution,
+            attrs=attrs,
+            metrics=ms,
+            root=bounds,
+            xsize=1000,
+            ysize=1000
+        )
+
+        Storage.create(sc)
 
     def test_metrics(self, storage: Storage):
         m_list = storage.get_metrics()


### PR DESCRIPTION
Adds user protection from out of bounds errors with the x and y tile sizes in the Storage creation, as well as a test to make sure that it's working as intended.